### PR TITLE
[codex] Add builder validation, prerequisite resolution, and smoke tests

### DIFF
--- a/.github/workflows/builder-smoke-tests.yml
+++ b/.github/workflows/builder-smoke-tests.yml
@@ -1,0 +1,27 @@
+name: Builder Smoke Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.8'
+          - '3.11'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run builder smoke tests
+        run: python -m unittest discover -s tests -v

--- a/builder/build_sd.py
+++ b/builder/build_sd.py
@@ -5,19 +5,22 @@ Assembles selected modules into a complete, ready-to-use SD card package
 for Audi/VW MMI3G, MMI3G+, and RNS-850 infotainment systems.
 
 Usage:
-    python build_sd.py --list                    List available modules
-    python build_sd.py --all -o ./sdcard         Build with all modules
+    python build_sd.py --list                              List available modules
+    python build_sd.py --all -o ./sdcard                  Build with all ready modules
+    python build_sd.py --all --target-platform RNS-850    Build only RNS-850-safe modules
     python build_sd.py -m gauges-dashboard -m system-info -o ./sdcard
-    python build_sd.py -m gauges-dashboard -o F:  Build directly to SD card
+    python build_sd.py -m gauges-dashboard -o F:          Build directly to SD card
 
 The builder:
-  1. Copies core files (encoded copie_scr.sh, run.sh)
-  2. Copies selected module files (engdefs, scripts)
-  3. Generates a combined run.sh that installs all selected modules
-  4. Creates the required directory structure (bin, lib, var)
+  1. Validates module manifests before doing any work
+  2. Copies core files (encoded copie_scr.sh, run.sh)
+  3. Copies selected module files (engdefs, scripts, artifacts)
+  4. Generates a combined run.sh that installs all selected modules
+  5. Creates the required directory structure (bin, lib, var)
 """
 
 import argparse
+from collections import OrderedDict
 import json
 import os
 import shutil
@@ -29,42 +32,307 @@ REPO_ROOT = os.path.dirname(SCRIPT_DIR)
 MODULES_DIR = os.path.join(REPO_ROOT, 'modules')
 CORE_DIR = os.path.join(REPO_ROOT, 'core')
 
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
 
-def find_modules() -> dict:
-    """Discover all available modules."""
+from encoder import MMI3GCipher
+
+
+SUPPORTED_PLATFORMS = ('MMI3G', 'MMI3G+', 'RNS-850')
+REQUIRED_MANIFEST_FIELDS = (
+    'name',
+    'version',
+    'description',
+    'author',
+    'status',
+    'compatible',
+)
+
+
+class ModuleConfigError(Exception):
+    """Raised when module metadata is invalid."""
+
+
+def module_is_compatible(meta: dict, target_platform: str = None) -> bool:
+    """Return True if the module supports the requested target platform."""
+    return target_platform is None or target_platform in meta.get('compatible', [])
+
+
+def parse_manifest_asset(entry, expected_ext: str) -> str:
+    """Extract a filename from a manifest asset declaration."""
+    if not isinstance(entry, str) or not entry.strip():
+        raise ModuleConfigError(
+            f"Manifest asset entries must be non-empty strings, got {entry!r}"
+        )
+
+    filename = entry.split(' - ', 1)[0].strip()
+    if not filename.endswith(expected_ext):
+        raise ModuleConfigError(
+            f"Manifest asset '{entry}' does not reference a {expected_ext} file"
+        )
+    return filename
+
+
+def validate_declared_assets(
+    mod_name: str,
+    mod_dir: str,
+    meta: dict,
+    manifest_key: str,
+    subdir: str,
+    expected_ext: str,
+) -> list:
+    """Validate that manifest-declared files exist on disk."""
+    errors = []
+    declarations = meta.get(manifest_key)
+    if declarations is None:
+        return errors
+
+    if not isinstance(declarations, list):
+        errors.append(f"'{manifest_key}' must be a list")
+        return errors
+
+    for entry in declarations:
+        try:
+            filename = parse_manifest_asset(entry, expected_ext)
+        except ModuleConfigError as exc:
+            errors.append(str(exc))
+            continue
+
+        asset_path = os.path.join(mod_dir, subdir, filename)
+        if not os.path.isfile(asset_path):
+            errors.append(
+                f"declares {manifest_key[:-1]} '{filename}' but file is missing at "
+                f"{asset_path}"
+            )
+
+    return errors
+
+
+def validate_module_metadata(mod_name: str, mod_dir: str, meta: dict):
+    """Validate a single module manifest."""
+    errors = []
+
+    missing = [field for field in REQUIRED_MANIFEST_FIELDS if field not in meta]
+    if missing:
+        errors.append(f"missing required field(s): {', '.join(missing)}")
+
+    if meta.get('name') != mod_name:
+        errors.append(
+            f"'name' must match the module directory ('{mod_name}'), "
+            f"got {meta.get('name')!r}"
+        )
+
+    compatible = meta.get('compatible')
+    if compatible is not None:
+        if not isinstance(compatible, list) or not compatible:
+            errors.append("'compatible' must be a non-empty list")
+        else:
+            invalid = [
+                platform
+                for platform in compatible
+                if platform not in SUPPORTED_PLATFORMS
+            ]
+            if invalid:
+                errors.append(
+                    f"unsupported platform(s) in 'compatible': {', '.join(invalid)}"
+                )
+
+    for field in ('version', 'description', 'author', 'status'):
+        value = meta.get(field)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            errors.append(f"'{field}' must be a non-empty string")
+
+    prereq = meta.get('prereq')
+    if prereq is not None:
+        if not isinstance(prereq, str) or not prereq.strip():
+            errors.append("'prereq' must be a non-empty string when present")
+        elif prereq == mod_name:
+            errors.append("'prereq' cannot point to the module itself")
+
+    script_dir = meta.get('script_dir')
+    if script_dir is not None:
+        if not isinstance(script_dir, str) or not script_dir.startswith('/'):
+            errors.append("'script_dir' must be an absolute flash path when present")
+
+    standalone = bool(meta.get('standalone'))
+    run_script = meta.get('run_script')
+    if standalone and not run_script:
+        errors.append("'standalone' modules must declare 'run_script'")
+    if run_script is not None:
+        if not isinstance(run_script, str) or not run_script.endswith('.sh'):
+            errors.append("'run_script' must name a .sh file")
+        else:
+            run_script_path = os.path.join(mod_dir, 'scripts', run_script)
+            if not os.path.isfile(run_script_path):
+                errors.append(
+                    f"declares run_script '{run_script}' but file is missing at "
+                    f"{run_script_path}"
+                )
+
+    artifact = meta.get('artifact')
+    if artifact is not None:
+        if not isinstance(artifact, str) or not artifact.strip():
+            errors.append("'artifact' must be a non-empty filename when present")
+        else:
+            artifact_path = os.path.join(mod_dir, artifact)
+            if not os.path.isfile(artifact_path):
+                errors.append(
+                    f"declares artifact '{artifact}' but file is missing at "
+                    f"{artifact_path}"
+                )
+
+    errors.extend(
+        validate_declared_assets(mod_name, mod_dir, meta, 'screens', 'engdefs', '.esd')
+    )
+    errors.extend(
+        validate_declared_assets(mod_name, mod_dir, meta, 'scripts', 'scripts', '.sh')
+    )
+
+    if errors:
+        raise ModuleConfigError(f"module '{mod_name}': " + '; '.join(errors))
+
+
+def load_module_metadata(mod_name: str, mod_dir: str) -> dict:
+    """Load and validate one module manifest."""
+    meta_file = os.path.join(mod_dir, 'module.json')
+    try:
+        with open(meta_file, 'r', encoding='utf-8') as f:
+            meta = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ModuleConfigError(
+            f"module '{mod_name}': invalid JSON in {meta_file}: {exc}"
+        )
+
+    validate_module_metadata(mod_name, mod_dir, meta)
+    meta['_dir'] = mod_dir
+    meta['_name'] = mod_name
+    return meta
+
+
+def validate_module_relationships(modules: dict):
+    """Validate cross-module references such as prerequisites."""
+    for mod_name, meta in modules.items():
+        prereq = meta.get('prereq')
+        if not prereq:
+            continue
+
+        if prereq not in modules:
+            raise ModuleConfigError(
+                f"module '{mod_name}' requires unknown prerequisite '{prereq}'"
+            )
+
+        prereq_compat = set(modules[prereq].get('compatible', []))
+        missing_platforms = [
+            platform for platform in meta.get('compatible', [])
+            if platform not in prereq_compat
+        ]
+        if missing_platforms:
+            raise ModuleConfigError(
+                f"module '{mod_name}' requires '{prereq}', but '{prereq}' is not "
+                f"compatible with: {', '.join(missing_platforms)}"
+            )
+
+
+def find_modules(modules_dir: str = None) -> dict:
+    """Discover all available modules and validate their manifests."""
     modules = {}
-    if not os.path.isdir(MODULES_DIR):
+    modules_dir = modules_dir or MODULES_DIR
+    if not os.path.isdir(modules_dir):
         return modules
-    
-    for name in sorted(os.listdir(MODULES_DIR)):
-        mod_dir = os.path.join(MODULES_DIR, name)
+
+    for name in sorted(os.listdir(modules_dir)):
+        mod_dir = os.path.join(modules_dir, name)
         meta_file = os.path.join(mod_dir, 'module.json')
         if os.path.isdir(mod_dir) and os.path.isfile(meta_file):
-            with open(meta_file, 'r') as f:
-                meta = json.load(f)
-            meta['_dir'] = mod_dir
-            meta['_name'] = name
-            modules[name] = meta
-    
+            modules[name] = load_module_metadata(name, mod_dir)
+
+    validate_module_relationships(modules)
     return modules
 
 
-def list_modules(modules: dict):
+def list_modules(modules: dict, target_platform: str = None):
     """Print available modules."""
     print("Available modules:")
     print("=" * 60)
+
+    found = False
     for name, meta in modules.items():
-        status = "ready" if meta.get('status') == 'ready' else meta.get('status', 'unknown')
+        if not module_is_compatible(meta, target_platform):
+            continue
+
+        found = True
+        status = meta.get('status', 'unknown')
         compat = ', '.join(meta.get('compatible', ['MMI3G+']))
         print(f"  {name}")
         print(f"    {meta.get('description', 'No description')}")
         print(f"    Status: {status} | Compatible: {compat}")
         print()
 
+    if not found and target_platform:
+        print(f"  No modules compatible with {target_platform}.")
+
+
+def resolve_selected_modules(
+    selected_modules: list,
+    modules: dict,
+    target_platform: str = None,
+) -> tuple:
+    """Resolve prerequisites and platform compatibility for a selection."""
+    requested = list(OrderedDict.fromkeys(selected_modules))
+    requested_set = set(requested)
+    incompatible = [
+        name
+        for name in requested
+        if not module_is_compatible(modules[name], target_platform)
+    ]
+    if incompatible:
+        raise ModuleConfigError(
+            f"selected module(s) not compatible with {target_platform}: "
+            f"{', '.join(incompatible)}"
+        )
+
+    resolved = []
+    visiting = []
+    auto_added_by = {}
+
+    def visit(mod_name: str):
+        if mod_name in resolved:
+            return
+        if mod_name in visiting:
+            cycle = visiting[visiting.index(mod_name):] + [mod_name]
+            raise ModuleConfigError(
+                f"circular prerequisite chain detected: {' -> '.join(cycle)}"
+            )
+
+        visiting.append(mod_name)
+        prereq = modules[mod_name].get('prereq')
+        if prereq:
+            if prereq not in modules:
+                raise ModuleConfigError(
+                    f"module '{mod_name}' requires unknown prerequisite '{prereq}'"
+                )
+            if prereq not in requested_set and prereq not in auto_added_by:
+                auto_added_by[prereq] = mod_name
+            visit(prereq)
+        visiting.pop()
+
+        if mod_name not in resolved:
+            resolved.append(mod_name)
+
+    for mod_name in requested:
+        visit(mod_name)
+
+    auto_added = [
+        (mod_name, auto_added_by[mod_name])
+        for mod_name in resolved
+        if mod_name in auto_added_by
+    ]
+    return resolved, auto_added
+
 
 def generate_run_sh(selected_modules: list, modules: dict) -> str:
     """Generate the combined run.sh for selected modules."""
-    
+
     lines = [
         '#!/bin/ksh',
         '# ============================================================',
@@ -114,13 +382,13 @@ def generate_run_sh(selected_modules: list, modules: dict) -> str:
         'echo ""',
         '',
     ]
-    
+
     # Add install section for each module
     for mod_name in selected_modules:
         meta = modules[mod_name]
         lines.append(f'# --- Module: {mod_name} ---')
         lines.append(f'echo "[MODULE] Installing {mod_name}..."')
-        
+
         # Check if module has a standalone run script
         # (e.g. gem-activator runs its own install logic)
         if meta.get('standalone') and meta.get('run_script'):
@@ -131,7 +399,7 @@ def generate_run_sh(selected_modules: list, modules: dict) -> str:
             lines.append(f'else')
             lines.append(f'    echo "[WARN] {run_script} not found for {mod_name}"')
             lines.append(f'fi')
-            
+
             # Also install scripts to flash for future use from GEM
             scripts_dir = os.path.join(meta['_dir'], 'scripts')
             if os.path.isdir(scripts_dir):
@@ -141,27 +409,33 @@ def generate_run_sh(selected_modules: list, modules: dict) -> str:
                 for script in sorted(os.listdir(scripts_dir)):
                     if script.endswith('.sh'):
                         lines.append(f'if [ -f "${{SDPATH}}/scripts/{script}" ]; then')
-                        lines.append(f'    cp -v "${{SDPATH}}/scripts/{script}" "${{SCRIPTDIR}}/{script}"')
+                        lines.append(
+                            f'    cp -v "${{SDPATH}}/scripts/{script}" '
+                            f'"${{SCRIPTDIR}}/{script}"'
+                        )
                         lines.append(f'    chmod +x "${{SCRIPTDIR}}/{script}"')
                         lines.append(f'fi')
         else:
             # Standard module — install engdefs and scripts
-            
+
             # Install engdefs
             lines.append(f'if [ -d "${{SDPATH}}/engdefs" ]; then')
-            
+
             mod_dir = modules[mod_name]['_dir']
             engdefs_dir = os.path.join(mod_dir, 'engdefs')
             if os.path.isdir(engdefs_dir):
                 for esd in sorted(os.listdir(engdefs_dir)):
                     if esd.endswith('.esd'):
                         lines.append(f'    if [ -f "${{SDPATH}}/engdefs/{esd}" ]; then')
-                        lines.append(f'        cp -v "${{SDPATH}}/engdefs/{esd}" "${{ENGDEFS}}/{esd}"')
+                        lines.append(
+                            f'        cp -v "${{SDPATH}}/engdefs/{esd}" '
+                            f'"${{ENGDEFS}}/{esd}"'
+                        )
                         lines.append(f'        echo "[INST] {esd}"')
                         lines.append(f'    fi')
-            
+
             lines.append('fi')
-            
+
             # Install scripts
             scripts_dir = os.path.join(mod_dir, 'scripts')
             if os.path.isdir(scripts_dir):
@@ -169,21 +443,24 @@ def generate_run_sh(selected_modules: list, modules: dict) -> str:
                 lines.append(f'SCRIPTDIR="${{EFSDIR}}{script_dest}"')
                 lines.append(f'mkdir -p ${{SCRIPTDIR}}')
                 lines.append(f'if [ -d "${{SDPATH}}/scripts" ]; then')
-                
+
                 for script in sorted(os.listdir(scripts_dir)):
                     if script.endswith('.sh'):
                         lines.append(f'    if [ -f "${{SDPATH}}/scripts/{script}" ]; then')
-                        lines.append(f'        cp -v "${{SDPATH}}/scripts/{script}" "${{SCRIPTDIR}}/{script}"')
+                        lines.append(
+                            f'        cp -v "${{SDPATH}}/scripts/{script}" '
+                            f'"${{SCRIPTDIR}}/{script}"'
+                        )
                         lines.append(f'        chmod +x "${{SCRIPTDIR}}/{script}"')
                         lines.append(f'        echo "[INST] {script}"')
                         lines.append(f'    fi')
-                
+
                 lines.append('fi')
-        
+
         lines.append(f'echo "[OK] {mod_name} installed"')
         lines.append('echo ""')
         lines.append('')
-    
+
     # Summary
     lines.extend([
         '# --- Complete ---',
@@ -196,13 +473,13 @@ def generate_run_sh(selected_modules: list, modules: dict) -> str:
         'echo " Open GEM (CAR + BACK) to access new screens"',
         'echo "============================================"',
     ])
-    
+
     return '\n'.join(lines) + '\n'
 
 
 def build_sd(selected_modules: list, modules: dict, output_dir: str):
     """Build the SD card contents."""
-    
+
     print(f"Building SD card -> {output_dir}")
     print(f"Modules: {', '.join(selected_modules)}")
     print()
@@ -239,18 +516,16 @@ def build_sd(selected_modules: list, modules: dict, output_dir: str):
     # Create directory structure
     for d in ['bin', 'lib', 'var', 'engdefs', 'scripts']:
         os.makedirs(os.path.join(output_dir, d), exist_ok=True)
-    
+
     # Encode and copy copie_scr.sh
     template_path = os.path.join(CORE_DIR, 'copie_scr_plain.sh')
     if os.path.isfile(template_path):
-        from encoder import MMI3GCipher
-        
         with open(template_path, 'rb') as f:
             plaintext = f.read()
-        
+
         cipher = MMI3GCipher()
         encoded = cipher.process(plaintext)
-        
+
         copie_out = os.path.join(output_dir, 'copie_scr.sh')
         with open(copie_out, 'wb') as f:
             f.write(encoded)
@@ -267,12 +542,12 @@ def build_sd(selected_modules: list, modules: dict, output_dir: str):
             # Force LF line endings
             dst.write(src.read().replace(b'\r\n', b'\n'))
         print(f"  [OK] scripts/common/platform.sh")
-    
+
     # Copy module files
     for mod_name in selected_modules:
         meta = modules[mod_name]
         mod_dir = meta['_dir']
-        
+
         # Copy engdefs
         engdefs_src = os.path.join(mod_dir, 'engdefs')
         if os.path.isdir(engdefs_src):
@@ -283,7 +558,7 @@ def build_sd(selected_modules: list, modules: dict, output_dir: str):
                         os.path.join(output_dir, 'engdefs', f)
                     )
                     print(f"  [OK] engdefs/{f}")
-        
+
         # Copy scripts
         scripts_src = os.path.join(mod_dir, 'scripts')
         if os.path.isdir(scripts_src):
@@ -300,30 +575,24 @@ def build_sd(selected_modules: list, modules: dict, output_dir: str):
         artifact = meta.get('artifact')
         if artifact:
             artifact_src = os.path.join(mod_dir, artifact)
-            if os.path.isfile(artifact_src):
-                # Artifacts go into modules/{name}/ on the SD to keep them
-                # separate from engdefs/ and scripts/ (which are flat).
-                art_dest_dir = os.path.join(output_dir, 'modules', mod_name)
-                os.makedirs(art_dest_dir, exist_ok=True)
-                shutil.copy2(artifact_src, os.path.join(art_dest_dir, artifact))
-                print(f"  [OK] modules/{mod_name}/{artifact}")
-            else:
-                print(f"  [WARN] {mod_name} declares artifact '{artifact}' but file not found at {artifact_src}")
-                print(f"         Build it first — see {mod_dir}/build.sh")
-    
+            art_dest_dir = os.path.join(output_dir, 'modules', mod_name)
+            os.makedirs(art_dest_dir, exist_ok=True)
+            shutil.copy2(artifact_src, os.path.join(art_dest_dir, artifact))
+            print(f"  [OK] modules/{mod_name}/{artifact}")
+
     # Generate combined run.sh
     run_sh = generate_run_sh(selected_modules, modules)
     run_path = os.path.join(output_dir, 'run.sh')
     with open(run_path, 'w', newline='\n') as f:
         f.write(run_sh)
     print(f"  [OK] run.sh generated")
-    
+
     # Copy uninstall script
     uninstall_src = os.path.join(CORE_DIR, 'uninstall.sh')
     if os.path.isfile(uninstall_src):
         shutil.copy2(uninstall_src, os.path.join(output_dir, 'uninstall.sh'))
         print(f"  [OK] uninstall.sh")
-    
+
     print()
     print("=" * 50)
     print("SD card build complete!")
@@ -354,7 +623,6 @@ def build_uninstall_sd(output_dir: str):
         print(f"[ERROR] {template_path} not found")
         sys.exit(1)
 
-    from encoder import MMI3GCipher
     with open(template_path, 'rb') as f:
         plaintext = f.read()
     encoded = MMI3GCipher().process(plaintext)
@@ -398,34 +666,41 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s --list                         List available modules
-  %(prog)s --all -o ./sdcard              Build with everything
-  %(prog)s -m gauges-dashboard -o F:\\     Build to SD card drive
+  %(prog)s --list                                      List available modules
+  %(prog)s --all -o ./sdcard                           Build with everything
+  %(prog)s --all --target-platform RNS-850 -o ./sdcard Build RNS-850-safe modules
+  %(prog)s -m gauges-dashboard -o F:\\                  Build to SD card drive
   %(prog)s -m gauges-dashboard -m system-info -o ./sdcard
         """
     )
-    
+
     parser.add_argument('--list', action='store_true',
                         help='List available modules')
     parser.add_argument('-m', '--module', action='append', dest='modules',
                         help='Module to include (can specify multiple)')
     parser.add_argument('--all', action='store_true',
                         help='Include all ready modules')
+    parser.add_argument('--target-platform', choices=SUPPORTED_PLATFORMS,
+                        help='Only include modules compatible with the specified platform')
     parser.add_argument('--uninstall', action='store_true',
                         help='Build an SD card that removes all toolkit modules from the MMI')
     parser.add_argument('-o', '--output', default='./sdcard',
                         help='Output directory (default: ./sdcard)')
-    
+
     args = parser.parse_args()
-    
-    available = find_modules()
-    
+
+    try:
+        available = find_modules()
+    except ModuleConfigError as exc:
+        print(f"[ERROR] {exc}")
+        sys.exit(1)
+
     if not available:
         print("No modules found! Check that the modules/ directory exists.")
         sys.exit(1)
-    
+
     if args.list:
-        list_modules(available)
+        list_modules(available, args.target_platform)
         return
 
     # Handle --uninstall: build an SD whose run.sh just calls uninstall.sh
@@ -435,23 +710,45 @@ Examples:
 
     # Determine which modules to build
     if args.all:
-        selected = [n for n, m in available.items() if m.get('status') == 'ready']
+        selected = [
+            n for n, m in available.items()
+            if m.get('status') == 'ready' and module_is_compatible(m, args.target_platform)
+        ]
     elif args.modules:
         selected = []
-        for m in args.modules:
-            if m not in available:
-                print(f"Unknown module: {m}")
+        for mod_name in args.modules:
+            if mod_name not in available:
+                print(f"Unknown module: {mod_name}")
                 print(f"Available: {', '.join(available.keys())}")
                 sys.exit(1)
-            selected.append(m)
+            selected.append(mod_name)
     else:
         parser.print_help()
         sys.exit(1)
-    
-    if not selected:
-        print("No modules selected!")
+
+    try:
+        selected, auto_added = resolve_selected_modules(
+            selected,
+            available,
+            target_platform=args.target_platform,
+        )
+    except ModuleConfigError as exc:
+        print(f"[ERROR] {exc}")
         sys.exit(1)
-    
+
+    if not selected:
+        if args.target_platform:
+            print(f"No modules selected for target platform {args.target_platform}!")
+        else:
+            print("No modules selected!")
+        sys.exit(1)
+
+    if auto_added:
+        print("Auto-including prerequisite module(s):")
+        for prereq, dependent in auto_added:
+            print(f"  {prereq} (required by {dependent})")
+        print()
+
     build_sd(selected, available, args.output)
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,6 +26,7 @@
 ## Module Guidelines
 
 - Set `status` to `"planned"` until tested on real hardware
+- Keep `screens`, `scripts`, `run_script`, and `artifact` entries in sync with real files
 - All scripts must handle missing SD card gracefully
 - Use `/bin/ksh` shebang (QNX default shell)
 - Log output to `${SDPATH}/var/` on the SD card
@@ -58,6 +59,12 @@ slider value per 3 0x00140007 0 31 label "Setting:"
 - `per 7` = GPS / Navigation data
 
 ## Testing
+
+Run the local builder smoke tests before opening a PR:
+`python -m unittest discover -s tests -v`
+
+These tests validate manifest loading, prerequisite resolution, target-platform
+filtering, and the core SD-card build flows. They do not replace on-car testing.
 
 Always test on a real MMI3G unit before marking a module as `ready`.
 The QNX 6.5.0 SP1 VM can verify script syntax but cannot simulate

--- a/tests/test_build_sd.py
+++ b/tests/test_build_sd.py
@@ -1,0 +1,221 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = REPO_ROOT / 'builder' / 'build_sd.py'
+
+
+def load_builder_module():
+    spec = importlib.util.spec_from_file_location('mmi3g_build_sd', BUILD_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BuildSdCliTests(unittest.TestCase):
+    def run_builder(self, *args):
+        return subprocess.run(
+            [sys.executable, str(BUILD_SCRIPT), *args],
+            cwd=str(REPO_ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+    def test_list_modules(self):
+        result = self.run_builder('--list')
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn('Available modules:', result.stdout)
+        self.assertIn('system-info', result.stdout)
+        self.assertIn('lte-setup', result.stdout)
+
+    def test_build_single_module_smoke(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder('-m', 'system-info', '-o', str(output_dir))
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertTrue((output_dir / 'copie_scr.sh').is_file())
+            self.assertTrue((output_dir / 'run.sh').is_file())
+            self.assertTrue((output_dir / 'uninstall.sh').is_file())
+            self.assertTrue((output_dir / 'scripts' / 'sysinfo_dump.sh').is_file())
+            self.assertTrue((output_dir / 'scripts' / 'common' / 'platform.sh').is_file())
+
+    def test_generated_copie_scr_round_trips_to_plaintext_template(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder('-m', 'system-info', '-o', str(output_dir))
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+            builder = load_builder_module()
+            encoded = (output_dir / 'copie_scr.sh').read_bytes()
+            decoded = builder.MMI3GCipher().process(encoded)
+            expected = (REPO_ROOT / 'core' / 'copie_scr_plain.sh').read_bytes()
+            self.assertEqual(decoded, expected)
+
+    def test_prerequisite_module_is_auto_included(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder('-m', 'can-scanner', '-o', str(output_dir))
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertIn('Auto-including prerequisite module(s):', result.stdout)
+            self.assertIn('gem-activator (required by can-scanner)', result.stdout)
+            self.assertTrue((output_dir / 'engdefs' / 'ToolkitMain.esd').is_file())
+            self.assertTrue((output_dir / 'engdefs' / 'ScannerPer3Low.esd').is_file())
+
+            run_sh = (output_dir / 'run.sh').read_text(encoding='utf-8')
+            self.assertLess(
+                run_sh.index('Installing gem-activator'),
+                run_sh.index('Installing can-scanner'),
+            )
+
+    def test_uninstall_builder_smoke(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'uninstall'
+            result = self.run_builder('--uninstall', '-o', str(output_dir))
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            run_sh = output_dir / 'run.sh'
+            uninstall_sh = output_dir / 'uninstall.sh'
+            self.assertTrue((output_dir / 'copie_scr.sh').is_file())
+            self.assertTrue(run_sh.is_file())
+            self.assertTrue(uninstall_sh.is_file())
+            self.assertEqual(run_sh.read_text(encoding='utf-8'), uninstall_sh.read_text(encoding='utf-8'))
+            self.assertNotIn(b'\r\n', run_sh.read_bytes())
+
+    def test_target_platform_rejects_incompatible_module(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self.run_builder(
+                '-m', 'lte-setup',
+                '--target-platform', 'MMI3G',
+                '-o', str(Path(tmpdir) / 'sdcard'),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('not compatible with MMI3G', result.stdout)
+
+    def test_all_with_target_platform_excludes_incompatible_ready_modules(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder(
+                '--all',
+                '--target-platform', 'MMI3G',
+                '-o', str(output_dir),
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertFalse((output_dir / 'scripts' / 'lte_setup.sh').exists())
+
+    def test_target_platform_list_filters_modules(self):
+        result = self.run_builder('--list', '--target-platform', 'MMI3G')
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn('system-info', result.stdout)
+        self.assertNotIn('lte-setup', result.stdout)
+
+    def test_standalone_module_build_contains_expected_runner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder(
+                '-m', 'lte-setup',
+                '--target-platform', 'RNS-850',
+                '-o', str(output_dir),
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            self.assertTrue((output_dir / 'scripts' / 'lte_setup.sh').is_file())
+            self.assertTrue((output_dir / 'scripts' / 'lte_restore.sh').is_file())
+            self.assertTrue((output_dir / 'scripts' / 'lte_status.sh').is_file())
+
+            run_sh = (output_dir / 'run.sh').read_text(encoding='utf-8')
+            self.assertIn('ksh "${SDPATH}/scripts/lte_setup.sh" "${SDPATH}"', run_sh)
+            self.assertIn('scripts/common/platform.sh', run_sh)
+
+    def test_all_build_for_rns850_writes_expected_fake_sd_tree(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / 'sdcard'
+            result = self.run_builder(
+                '--all',
+                '--target-platform', 'RNS-850',
+                '-o', str(output_dir),
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+            for dirname in ('bin', 'lib', 'var', 'engdefs', 'scripts'):
+                self.assertTrue((output_dir / dirname).is_dir(), dirname)
+
+            self.assertTrue((output_dir / 'scripts' / 'lte_setup.sh').is_file())
+            self.assertTrue((output_dir / 'engdefs' / 'ToolkitMain.esd').is_file())
+            self.assertTrue((output_dir / 'engdefs' / 'ScannerPer3Low.esd').is_file())
+            self.assertFalse((output_dir / 'scripts' / 'per3_read.sh').exists())
+            self.assertFalse((output_dir / 'modules' / 'per3-reader').exists())
+
+
+class BuildSdValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.builder = load_builder_module()
+
+    def test_resolve_selected_modules_adds_prereq_once(self):
+        available = self.builder.find_modules()
+
+        resolved, auto_added = self.builder.resolve_selected_modules(
+            ['can-scanner', 'game-loader'],
+            available,
+        )
+
+        self.assertEqual(resolved[0], 'gem-activator')
+        self.assertEqual(resolved.count('gem-activator'), 1)
+        self.assertIn(('gem-activator', 'can-scanner'), auto_added)
+
+    def test_find_modules_rejects_invalid_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            modules_dir = Path(tmpdir) / 'modules'
+            bad_dir = modules_dir / 'broken'
+            bad_dir.mkdir(parents=True)
+            (bad_dir / 'module.json').write_text('{broken json', encoding='utf-8')
+
+            with mock.patch.object(self.builder, 'MODULES_DIR', str(modules_dir)):
+                with self.assertRaises(self.builder.ModuleConfigError):
+                    self.builder.find_modules()
+
+    def test_find_modules_rejects_missing_declared_run_script(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            modules_dir = Path(tmpdir) / 'modules'
+            bad_dir = modules_dir / 'broken'
+            bad_dir.mkdir(parents=True)
+            (bad_dir / 'scripts').mkdir()
+            manifest = {
+                'name': 'broken',
+                'version': '1.0.0',
+                'description': 'broken module',
+                'author': 'test',
+                'status': 'ready',
+                'compatible': ['MMI3G'],
+                'standalone': True,
+                'run_script': 'missing.sh',
+            }
+            (bad_dir / 'module.json').write_text(
+                json.dumps(manifest, indent=2),
+                encoding='utf-8',
+            )
+
+            with mock.patch.object(self.builder, 'MODULES_DIR', str(modules_dir)):
+                with self.assertRaises(self.builder.ModuleConfigError) as exc:
+                    self.builder.find_modules()
+
+            self.assertIn('run_script', str(exc.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR hardens the SD-card builder by turning existing module metadata into enforced behavior and adding automated regression coverage around the main build flows.

Changes in this PR:
- validate `module.json` manifests before building
- enforce declared prerequisites when selecting modules
- add `--target-platform` filtering and enforcement based on `compatible`
- add builder smoke and regression tests
- add GitHub Actions coverage for the builder tests
- document the local test command in `docs/CONTRIBUTING.md`

## Intentional behavior change

The builder now resolves declared prerequisites before generating `run.sh`.

This changes install order for dependent modules. Most notably, `gem-activator` now installs before modules that depend on it, such as `can-scanner`.

Side-by-side fake-SD diffs against the previous builder showed identical output for unchanged flows; the only observed legacy flow difference was this `run.sh` ordering change under `--all`.

## Validation scope

This PR adds builder and CI validation, not on-car validation.

Coverage added here includes:
- manifest validation
- prerequisite resolution
- target-platform filtering
- fake SD-card output generation
- regression checks against previous builder behavior

Validated locally with:
- `python3 -m unittest discover -s tests -v` (`13/13` passing)
- side-by-side old-vs-new fake-SD comparisons

Observed old-vs-new parity:
- `--list`: exact match
- `-m system-info`: byte-identical fake-SD output
- `-m lte-setup`: byte-identical fake-SD output
- `-m gem-activator -m can-scanner`: byte-identical fake-SD output
- `--uninstall`: byte-identical fake-SD output
- `--all`: only `run.sh` differed, due to prerequisite-driven install ordering

Additional checks:
- generated `copie_scr.sh` decodes back to `core/copie_scr_plain.sh`
- generated shell payloads pass syntax parsing
- fake `--all --target-platform RNS-850` builds complete successfully

## Notes

This does not prove QNX runtime behavior or real-vehicle behavior. On-car testing is still required before claiming hardware-level safety.
