### PR TITLE
feat: add lsd.jxe inspection and portable IFS extraction fallback

### DIFF
--- a/tests/test_firmware_tools.py
+++ b/tests/test_firmware_tools.py
@@ -185,6 +185,19 @@ class InflateIfsTests(unittest.TestCase):
         self.assertIn('/mnt/host1/extracted', command_text)
         self.assertIn('--no-container-fallback', command_text)
 
+    def test_build_container_command_adds_selinux_compat_for_docker(self):
+        command = self.module.build_container_command(
+            container_tool='docker',
+            image='debian:bookworm-slim',
+            ifs_path='/tmp/ifs-root.ifs',
+            output_path='/tmp/ifs-root.decomp',
+            repo_root='/repo/MMI3G-Toolkit',
+        )
+
+        command_text = ' '.join(command)
+        self.assertIn('docker run --rm', command_text)
+        self.assertIn('--security-opt label=disable', command_text)
+
     def test_translate_host_path_prefers_workspace_for_repo_files(self):
         repo_root = '/repo/MMI3G-Toolkit'
         translated = self.module.translate_host_path(

--- a/tests/test_firmware_tools.py
+++ b/tests/test_firmware_tools.py
@@ -1,0 +1,169 @@
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+import unittest
+import zipfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EOL_MODIFIER = REPO_ROOT / 'tools' / 'eol_modifier.py'
+INFLATE_IFS = REPO_ROOT / 'tools' / 'inflate_ifs.py'
+
+
+def load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EolModifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_module(EOL_MODIFIER, 'mmi3g_eol_modifier_test')
+
+    def make_sample_jxe(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        jxe_path = Path(tmpdir.name) / 'sample_lsd.jxe'
+
+        with zipfile.ZipFile(jxe_path, 'w', compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr(
+                'resources/sysconst/sysconst.properties',
+                '\n'.join([
+                    'EOLFLAG_GOOGLE_EARTH=0',
+                    'EOLFLAG_INNOVATIONFEATURES=0',
+                    'EOLFLAG_HU_REGION=0',
+                    '',
+                ]),
+            )
+            zf.writestr(
+                'resources/sysconst/variant.properties',
+                '\n'.join([
+                    'variant=vw_high_nar no_online_services',
+                    'market=nar',
+                    '',
+                ]),
+            )
+            zf.writestr(
+                'resources/sysconst/variants/vw_high_nar.properties',
+                '\n'.join([
+                    'EOLFLAG_HU_VARIANT=15',
+                    'EOLFLAG_HU_REGION=1',
+                    '',
+                ]),
+            )
+            zf.writestr(
+                'resources/sysconst/variants/no_online_services.properties',
+                '\n'.join([
+                    'RANGE_EOLFLAG_GOOGLE_EARTH=0',
+                    '',
+                ]),
+            )
+            zf.writestr(
+                'resources/sysconst/variants/high_nav_nar.properties',
+                '\n'.join([
+                    'EOLFLAG_INNOVATIONFEATURES=1',
+                    'EOLFLAG_HU_VARIANT=6',
+                    '',
+                ]),
+            )
+
+        return tmpdir, jxe_path
+
+    def test_infer_active_variants_from_variant_selector(self):
+        tmpdir, jxe_path = self.make_sample_jxe()
+        self.addCleanup(tmpdir.cleanup)
+
+        config = self.module.load_jxe_config(str(jxe_path))
+        inferred = self.module.infer_active_variants(
+            config['selector_props'],
+            config['variants'].keys(),
+        )
+
+        self.assertEqual(inferred, ['vw_high_nar', 'no_online_services'])
+
+    def test_compose_effective_values_applies_range_lock(self):
+        tmpdir, jxe_path = self.make_sample_jxe()
+        self.addCleanup(tmpdir.cleanup)
+
+        config = self.module.load_jxe_config(str(jxe_path))
+        raw, ranges = self.module.compose_effective_values(
+            config,
+            ['vw_high_nar', 'no_online_services'],
+        )
+
+        self.assertEqual(raw['EOLFLAG_HU_REGION']['value'], '1')
+        self.assertEqual(raw['EOLFLAG_HU_REGION']['source'], 'vw_high_nar.properties')
+        self.assertEqual(ranges['EOLFLAG_GOOGLE_EARTH']['value'], '0')
+        self.assertEqual(ranges['EOLFLAG_GOOGLE_EARTH']['source'], 'no_online_services.properties')
+
+    def test_variant_summary_counts_range_entries(self):
+        tmpdir, jxe_path = self.make_sample_jxe()
+        self.addCleanup(tmpdir.cleanup)
+
+        config = self.module.load_jxe_config(str(jxe_path))
+        summary = self.module.variant_summary(
+            'no_online_services',
+            config['variants']['no_online_services']['props'],
+        )
+
+        self.assertEqual(summary['eol_count'], 0)
+        self.assertEqual(summary['range_count'], 1)
+        self.assertIsNone(summary['hu_variant'])
+
+
+class InflateIfsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_module(INFLATE_IFS, 'mmi3g_inflate_ifs_test')
+
+    def test_build_container_command_mounts_repo_and_external_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            repo_root = tmp_path / 'repo' / 'MMI3G-Toolkit'
+            firmware_root = tmp_path / 'firmware'
+            output_root = tmp_path / 'out'
+
+            repo_root.mkdir(parents=True)
+            firmware_root.mkdir()
+            output_root.mkdir()
+
+            ifs_path = firmware_root / 'ifs-root.ifs'
+            ifs_path.write_bytes(b'fake')
+            output_path = output_root / 'ifs-root.decomp'
+            extract_path = output_root / 'extracted'
+
+            command = self.module.build_container_command(
+                container_tool='podman',
+                image='debian:bookworm-slim',
+                ifs_path=str(ifs_path),
+                output_path=str(output_path),
+                extract_path=str(extract_path),
+                keep_decomp=False,
+                repo_root=str(repo_root),
+            )
+
+        command_text = ' '.join(command)
+        self.assertIn('podman run --rm', command_text)
+        self.assertIn('{}:/workspace'.format(repo_root), command_text)
+        self.assertIn('{}:/mnt/host0'.format(firmware_root), command_text)
+        self.assertIn('{}:/mnt/host1'.format(output_root), command_text)
+        self.assertIn('/workspace/tools/inflate_ifs.py', command_text)
+        self.assertIn('/mnt/host0/ifs-root.ifs', command_text)
+        self.assertIn('/mnt/host1/ifs-root.decomp', command_text)
+        self.assertIn('/mnt/host1/extracted', command_text)
+        self.assertIn('--no-container-fallback', command_text)
+
+    def test_translate_host_path_prefers_workspace_for_repo_files(self):
+        repo_root = '/repo/MMI3G-Toolkit'
+        translated = self.module.translate_host_path(
+            '/repo/MMI3G-Toolkit/tools/inflate_ifs.py',
+            repo_root,
+            [],
+        )
+        self.assertEqual(translated, '/workspace/tools/inflate_ifs.py')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_firmware_tools.py
+++ b/tests/test_firmware_tools.py
@@ -175,6 +175,7 @@ class InflateIfsTests(unittest.TestCase):
 
         command_text = ' '.join(command)
         self.assertIn('podman run --rm', command_text)
+        self.assertIn('--security-opt label=disable', command_text)
         self.assertIn('{}:/workspace'.format(repo_root), command_text)
         self.assertIn('{}:/mnt/host0'.format(firmware_root), command_text)
         self.assertIn('{}:/mnt/host1'.format(output_root), command_text)

--- a/tests/test_firmware_tools.py
+++ b/tests/test_firmware_tools.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 import unittest
 import zipfile
 
@@ -111,6 +112,34 @@ class EolModifierTests(unittest.TestCase):
         self.assertEqual(summary['eol_count'], 0)
         self.assertEqual(summary['range_count'], 1)
         self.assertIsNone(summary['hu_variant'])
+
+    def test_modify_jxe_keeps_google_earth_enable_flow(self):
+        tmpdir, jxe_path = self.make_sample_jxe()
+        self.addCleanup(tmpdir.cleanup)
+
+        output_path = Path(tmpdir.name) / 'modified_lsd.jxe'
+        self.module.modify_jxe(
+            str(jxe_path),
+            str(output_path),
+            {'EOLFLAG_GOOGLE_EARTH': '1'},
+        )
+
+        flags, _ = self.module.read_flags(str(output_path))
+        self.assertEqual(flags['EOLFLAG_GOOGLE_EARTH'], '1')
+        self.assertEqual(flags['EOLFLAG_INNOVATIONFEATURES'], '0')
+
+        with zipfile.ZipFile(output_path, 'r') as zf:
+            self.assertIn('resources/sysconst/variant.properties', zf.namelist())
+
+    def test_build_changes_accepts_google_earth_shorthand(self):
+        args = SimpleNamespace(
+            enable=['GOOGLE_EARTH'],
+            disable=[],
+            set=[],
+        )
+
+        changes = self.module.build_changes(args)
+        self.assertEqual(changes['EOLFLAG_GOOGLE_EARTH'], '1')
 
 
 class InflateIfsTests(unittest.TestCase):

--- a/tools/README.md
+++ b/tools/README.md
@@ -123,13 +123,28 @@ Format:
 The C decompressor (`qnx_ifs_decompress.c`, ~140 lines) is built
 automatically on first use.
 
+If local native deps are missing (`gcc`, `libucl-dev` / `libucl-devel`),
+the script can re-run itself inside a disposable `podman` or `docker`
+container. This is useful on fresh Fedora/macOS/Linux hosts where the
+toolchain is not installed yet.
+
 ```
 # Decompress only
 python3 tools/inflate_ifs.py ifs-root.ifs -o ifs-root.decomp
 
 # Decompress and extract to a directory (chains through extract_qnx_ifs.py)
 python3 tools/inflate_ifs.py ifs-root.ifs --extract outdir/
+
+# Force the disposable container path
+python3 tools/inflate_ifs.py ifs-root.ifs --extract outdir/ --container
 ```
+
+Container notes:
+- `--container` forces the disposable runtime path even if local native deps exist
+- without `--container`, the script auto-falls back to `podman` / `docker`
+  when the local native build fails
+- `--container-tool podman` or `--container-tool docker` pins the runtime
+- `--container-image` overrides the default image (`debian:bookworm-slim`)
 
 Verified on MU9411 K0942_4 variant 41:
 - `ifs-root.ifs`: LZO, 671 chunks → 104 MB uncompressed, 345 files
@@ -406,16 +421,43 @@ python3 tools/mu_repack.py \
 
 ## eol_modifier.py
 
-**Modify EOL (End-of-Line) feature flags in `lsd.jxe`.**
+**Inspect variant/range overlays and modify EOL (End-of-Line) feature flags in `lsd.jxe`.**
 
 EOL flags in `sysconst.properties` inside the `lsd.jxe` JAR control which
-features are available on the MMI3G head unit. This tool modifies flags to
-enable or disable features — particularly useful for enabling Google Earth
-on NAR units that have the code but not the UI flag set.
+features are available on the MMI3G head unit. This tool can now:
+
+- list base `sysconst.properties` EOL flags
+- show the raw `variant.properties` selector and infer active variant layers
+- list available `variants/*.properties` bundles with region / variant summaries
+- diff two variant bundles
+- show `RANGE_` constraints and effective values after overlaying variant bundles
+- modify base `sysconst.properties` flags for patching workflows
+
+This is particularly useful for Google Earth, market-gating, and other
+cases where the same binary contains the feature code but variant overlays
+or `RANGE_` constraints hide the UI.
 
 ```bash
 # List all flags and their current state
 python3 tools/eol_modifier.py /path/to/lsd.jxe --list
+
+# Show variant selector + inferred active layers
+python3 tools/eol_modifier.py /path/to/lsd.jxe --show-variant
+
+# List available variant bundles
+python3 tools/eol_modifier.py /path/to/lsd.jxe --list-variants
+
+# Compare Audi NAR vs VW NAR overlays
+python3 tools/eol_modifier.py /path/to/lsd.jxe \
+    --diff-variants high_nav_nar vw_high_nar
+
+# Inspect range locks / effective values for a chosen overlay stack
+python3 tools/eol_modifier.py /path/to/lsd.jxe \
+    --variant vw_high_nar \
+    --variant no_online_services \
+    --show-range-locks \
+    --show-effective GOOGLE_EARTH \
+    --show-effective INNOVATIONFEATURES
 
 # Enable Google Earth
 python3 tools/eol_modifier.py /path/to/lsd.jxe --output modified_lsd.jxe \
@@ -439,6 +481,12 @@ python3 tools/patch_ifs.py ifs_decomp.ifs ifs_patched.ifs \
 ```
 
 **Relevance to GEMMI/Google Earth restoration**: DrGER identified that NAR
-RNS-850 units lack the Google Earth UI in `lsd.jxe`. This tool can enable
-the `EOLFLAG_GOOGLE_EARTH` flag, which may be all that's needed for NAR
-units that have the GEMMI binaries but not the UI toggle.
+RNS-850 units lack the Google Earth UI in `lsd.jxe`. The inspection mode
+helps answer whether a feature is blocked by:
+
+- base `sysconst.properties` defaults,
+- the selected market / brand variant bundle,
+- or a hard `RANGE_` constraint such as `RANGE_EOLFLAG_GOOGLE_EARTH=0`.
+
+That makes `eol_modifier.py` useful as a read-only research tool even when
+you are not ready to patch `lsd.jxe` yet.

--- a/tools/README.md
+++ b/tools/README.md
@@ -145,9 +145,9 @@ Container notes:
   when the local native build fails
 - `--container-tool podman` or `--container-tool docker` pins the runtime
 - `--container-image` overrides the default image (`debian:bookworm-slim`)
-- on Fedora/SELinux hosts, the podman path disables label confinement for the
-  disposable container so it can read the repo and temp bind mounts without
-  relabeling host files
+- on Fedora/SELinux hosts, the disposable podman/docker path disables label
+  confinement so it can read the repo and temp bind mounts without relabeling
+  host files
 
 Verified on MU9411 K0942_4 variant 41:
 - `ifs-root.ifs`: LZO, 671 chunks → 104 MB uncompressed, 345 files

--- a/tools/README.md
+++ b/tools/README.md
@@ -145,6 +145,9 @@ Container notes:
   when the local native build fails
 - `--container-tool podman` or `--container-tool docker` pins the runtime
 - `--container-image` overrides the default image (`debian:bookworm-slim`)
+- on Fedora/SELinux hosts, the podman path disables label confinement for the
+  disposable container so it can read the repo and temp bind mounts without
+  relabeling host files
 
 Verified on MU9411 K0942_4 variant 41:
 - `ifs-root.ifs`: LZO, 671 chunks → 104 MB uncompressed, 345 files

--- a/tools/eol_modifier.py
+++ b/tools/eol_modifier.py
@@ -1,28 +1,36 @@
 #!/usr/bin/env python3
 """
-eol_modifier.py — modify EOL feature flags in lsd.jxe.
+eol_modifier.py — inspect and modify EOL feature flags in lsd.jxe.
 
 EOL (End-of-Line) flags in sysconst.properties control which features
-are available on the MMI3G head unit. This tool modifies flags inside
-the lsd.jxe JAR archive to enable/disable features.
+are available on the MMI3G head unit. This tool can both inspect the
+variant/range overlay stack inside lsd.jxe and modify base EOL flags.
 
 Usage:
-    # List all flags and their current state
+    # List master sysconst EOL flags
     python3 tools/eol_modifier.py /path/to/lsd.jxe --list
 
-    # Enable Google Earth
+    # Show raw variant selector and inferred active variant layers
+    python3 tools/eol_modifier.py /path/to/lsd.jxe --show-variant
+
+    # List available variant bundles with region / variant summaries
+    python3 tools/eol_modifier.py /path/to/lsd.jxe --list-variants
+
+    # Diff two variant bundles
+    python3 tools/eol_modifier.py /path/to/lsd.jxe \
+        --diff-variants vw_high_nar high_nav_nar
+
+    # Show RANGE_ locks and effective values for selected flags
+    python3 tools/eol_modifier.py /path/to/lsd.jxe \
+        --variant vw_high_nar \
+        --variant no_online_services \
+        --show-range-locks \
+        --show-effective GOOGLE_EARTH \
+        --show-effective INNOVATIONFEATURES
+
+    # Enable Google Earth in the base sysconst.properties
     python3 tools/eol_modifier.py /path/to/lsd.jxe --output modified_lsd.jxe \
         --enable EOLFLAG_GOOGLE_EARTH
-
-    # Enable multiple features
-    python3 tools/eol_modifier.py /path/to/lsd.jxe --output modified_lsd.jxe \
-        --enable EOLFLAG_GOOGLE_EARTH \
-        --enable EOLFLAG_ONLINE_SERVICES \
-        --enable EOLFLAG_INNOVATIONFEATURES
-
-    # Disable a feature
-    python3 tools/eol_modifier.py /path/to/lsd.jxe --output modified_lsd.jxe \
-        --disable EOLFLAG_DEVICES_TV
 
 After modifying lsd.jxe, deploy it with:
     python3 tools/patch_ifs.py ifs_decomp.ifs ifs_patched.ifs \
@@ -35,12 +43,14 @@ features your vehicle supports.
 import argparse
 import os
 import re
-import shutil
 import sys
 import zipfile
+from collections import OrderedDict
 
 
 SYSCONST_PATH = "resources/sysconst/sysconst.properties"
+VARIANT_SELECTOR_PATH = "resources/sysconst/variant.properties"
+VARIANTS_DIR = "resources/sysconst/variants/"
 
 # Features known to be safe to toggle
 SAFE_FEATURES = {
@@ -69,121 +79,435 @@ HARDWARE_FEATURES = {
 }
 
 
+def parse_properties(text):
+    """Parse a Java .properties file into an ordered dict."""
+    props = OrderedDict()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#') or line.startswith('!'):
+            continue
+        if '=' in line:
+            key, value = line.split('=', 1)
+        elif ':' in line:
+            key, value = line.split(':', 1)
+        else:
+            continue
+        props[key.strip()] = value.strip()
+    return props
+
+
+def read_zip_text(zf, path):
+    try:
+        return zf.read(path).decode('utf-8')
+    except KeyError:
+        return None
+
+
+def load_jxe_config(jxe_path):
+    """Load sysconst, variant selector, and variant bundles from lsd.jxe."""
+    with zipfile.ZipFile(jxe_path, 'r') as zf:
+        sysconst_text = zf.read(SYSCONST_PATH).decode('utf-8')
+        selector_text = read_zip_text(zf, VARIANT_SELECTOR_PATH)
+
+        variants = OrderedDict()
+        for name in sorted(zf.namelist()):
+            if not name.startswith(VARIANTS_DIR) or not name.endswith('.properties'):
+                continue
+            variant_name = os.path.basename(name)[:-len('.properties')]
+            variants[variant_name] = {
+                'path': name,
+                'text': zf.read(name).decode('utf-8'),
+            }
+
+    base_props = parse_properties(sysconst_text)
+    selector_props = parse_properties(selector_text or '')
+    for variant_name, variant_data in variants.items():
+        variant_data['props'] = parse_properties(variant_data['text'])
+
+    return {
+        'sysconst_text': sysconst_text,
+        'base_props': base_props,
+        'selector_text': selector_text or '',
+        'selector_props': selector_props,
+        'variants': variants,
+    }
+
+
 def read_flags(jxe_path):
-    """Read EOL flags from lsd.jxe."""
-    z = zipfile.ZipFile(jxe_path, 'r')
-    sc = z.read(SYSCONST_PATH).decode('utf-8')
-    z.close()
+    """Read base EOL flags from sysconst.properties."""
+    cfg = load_jxe_config(jxe_path)
+    flags = OrderedDict()
+    for name, value in cfg['base_props'].items():
+        if name.startswith('EOLFLAG_'):
+            flags[name] = value
+    return flags, cfg['sysconst_text']
 
-    flags = {}
-    for line in sc.split('\n'):
-        line = line.strip()
-        if line.startswith('EOLFLAG_') and '=' in line:
-            name, val = line.split('=', 1)
-            flags[name.strip()] = val.strip()
 
-    return flags, sc
+def normalize_flag_name(name):
+    if name.startswith('EOLFLAG_') or name.startswith('RANGE_'):
+        return name
+    return 'EOLFLAG_' + name
+
+
+def feature_description(flag_name):
+    return SAFE_FEATURES.get(flag_name, HARDWARE_FEATURES.get(flag_name, ''))
+
+
+def summarize_flags(flags):
+    disabled = {k: v for k, v in flags.items() if v == '0'}
+    enabled = {k: v for k, v in flags.items() if v != '0'}
+
+    print("=== Enabled ({}) ===".format(len(enabled)))
+    for key in sorted(enabled):
+        desc = feature_description(key)
+        suffix = '  — {}'.format(desc) if desc else ''
+        print("  {} = {}{}".format(key, enabled[key], suffix))
+
+    print("\n=== Disabled ({}) — can be enabled ===".format(len(disabled)))
+    for key in sorted(disabled):
+        desc = feature_description(key)
+        safe = '✓' if key in SAFE_FEATURES else '⚠' if key in HARDWARE_FEATURES else ' '
+        suffix = '  — {}'.format(desc) if desc else ''
+        print("  {} {} = 0{}".format(safe, key, suffix))
+
+    print("\n✓ = safe to enable  ⚠ = requires specific hardware")
+
+
+def infer_active_variants(selector_props, available_variants):
+    """Best-effort inference of active variant layers from variant.properties."""
+    available = set(available_variants)
+    inferred = []
+
+    def add_variant(name):
+        if name in available and name not in inferred:
+            inferred.append(name)
+
+    truthy = {'1', 'true', 'yes', 'on', 'active', 'enabled'}
+    splitter = re.compile(r'[,\s;|]+')
+
+    for key, value in selector_props.items():
+        if key in available and value.lower() in truthy:
+            add_variant(key)
+
+        for token in splitter.split(value):
+            token = token.strip()
+            if not token:
+                continue
+            if token.endswith('.properties'):
+                token = token[:-len('.properties')]
+            add_variant(token)
+
+    return inferred
+
+
+def get_variant_layers(config, explicit_variants):
+    """Return the ordered variant layers to inspect."""
+    if explicit_variants:
+        missing = [name for name in explicit_variants if name not in config['variants']]
+        if missing:
+            available = ', '.join(sorted(config['variants']))
+            raise KeyError(
+                "Unknown variant(s): {}. Available: {}".format(', '.join(missing), available)
+            )
+        return explicit_variants
+    return infer_active_variants(config['selector_props'], config['variants'].keys())
+
+
+def variant_summary(variant_name, variant_props):
+    eol_count = 0
+    range_count = 0
+    hu_variant = None
+    hu_region = None
+    for key, value in variant_props.items():
+        if key.startswith('EOLFLAG_'):
+            eol_count += 1
+        if key.startswith('RANGE_'):
+            range_count += 1
+        if key == 'EOLFLAG_HU_VARIANT':
+            hu_variant = value
+        elif key == 'EOLFLAG_HU_REGION':
+            hu_region = value
+    return {
+        'name': variant_name,
+        'eol_count': eol_count,
+        'range_count': range_count,
+        'hu_variant': hu_variant,
+        'hu_region': hu_region,
+    }
+
+
+def compose_effective_values(config, layer_names):
+    """Overlay base props with variant props and track source/range constraints."""
+    raw = {}
+    ranges = {}
+
+    for key, value in config['base_props'].items():
+        if key.startswith('EOLFLAG_'):
+            raw[key] = {'value': value, 'source': 'sysconst.properties'}
+        elif key.startswith('RANGE_'):
+            target = key[len('RANGE_'):]
+            ranges[target] = {'value': value, 'source': 'sysconst.properties'}
+
+    for layer_name in layer_names:
+        source = layer_name + '.properties'
+        for key, value in config['variants'][layer_name]['props'].items():
+            if key.startswith('EOLFLAG_'):
+                raw[key] = {'value': value, 'source': source}
+            elif key.startswith('RANGE_'):
+                target = key[len('RANGE_'):]
+                ranges[target] = {'value': value, 'source': source}
+
+    return raw, ranges
+
+
+def print_variant_selector(config):
+    print("=== Variant Selector ===")
+    if config['selector_text'].strip():
+        for key, value in config['selector_props'].items():
+            print("  {} = {}".format(key, value))
+    else:
+        print("  variant.properties not present in this lsd.jxe")
+
+    inferred = infer_active_variants(config['selector_props'], config['variants'].keys())
+    print("\n=== Inferred Active Variant Layers ===")
+    if inferred:
+        for index, name in enumerate(inferred, 1):
+            print("  {}. {}".format(index, name))
+    else:
+        print("  No variant layers inferred from variant.properties")
+
+
+def print_available_variants(config):
+    print("=== Available Variants ({}) ===".format(len(config['variants'])))
+    for name in sorted(config['variants']):
+        summary = variant_summary(name, config['variants'][name]['props'])
+        print(
+            "  {name:<28} EOL={eol_count:<4} RANGE={range_count:<3} "
+            "HU_VARIANT={hu_variant:<4} HU_REGION={hu_region}".format(
+                name=name,
+                eol_count=summary['eol_count'],
+                range_count=summary['range_count'],
+                hu_variant=summary['hu_variant'] if summary['hu_variant'] is not None else '-',
+                hu_region=summary['hu_region'] if summary['hu_region'] is not None else '-',
+            )
+        )
+
+
+def print_variant_diff(config, left_name, right_name):
+    left = config['variants'][left_name]['props']
+    right = config['variants'][right_name]['props']
+    keys = sorted(set(left) | set(right))
+
+    print("=== Variant Diff: {} vs {} ===".format(left_name, right_name))
+    changes = 0
+    for key in keys:
+        left_value = left.get(key)
+        right_value = right.get(key)
+        if left_value == right_value:
+            continue
+        changes += 1
+        print(
+            "  {}: {} -> {}".format(
+                key,
+                left_value if left_value is not None else '<unset>',
+                right_value if right_value is not None else '<unset>',
+            )
+        )
+    if changes == 0:
+        print("  No differences")
+
+
+def print_range_locks(config, layer_names):
+    if not layer_names:
+        print("=== RANGE Locks ===")
+        print("  No active or requested variant layers to inspect")
+        return
+
+    print("=== RANGE Locks ({}) ===".format(', '.join(layer_names)))
+    printed = 0
+    for layer_name in layer_names:
+        entries = []
+        for key, value in config['variants'][layer_name]['props'].items():
+            if key.startswith('RANGE_'):
+                entries.append((key, value))
+        if not entries:
+            continue
+        print("  [{}]".format(layer_name))
+        for key, value in entries:
+            target = key[len('RANGE_'):] if key.startswith('RANGE_') else key
+            print("    {} = {}  -> constrains {}".format(key, value, target))
+            printed += 1
+    if printed == 0:
+        print("  No RANGE_ constraints in the requested layers")
+
+
+def print_effective_flags(config, layer_names, requested_flags):
+    raw, ranges = compose_effective_values(config, layer_names)
+
+    print("=== Effective Flags ({}) ===".format(', '.join(layer_names) if layer_names else 'base only'))
+    for flag in requested_flags:
+        name = normalize_flag_name(flag)
+        raw_info = raw.get(name)
+        range_info = ranges.get(name)
+
+        raw_value = raw_info['value'] if raw_info else '<unset>'
+        raw_source = raw_info['source'] if raw_info else '-'
+        effective_value = range_info['value'] if range_info else raw_value
+        effective_source = range_info['source'] if range_info else raw_source
+        desc = feature_description(name)
+
+        print("  {}".format(name))
+        if desc:
+            print("    description : {}".format(desc))
+        print("    raw         : {} ({})".format(raw_value, raw_source))
+        if range_info:
+            print("    range lock  : {} ({})".format(range_info['value'], range_info['source']))
+            print("    effective   : {} (range-constrained)".format(effective_value))
+        else:
+            print("    effective   : {} ({})".format(effective_value, effective_source))
 
 
 def modify_jxe(jxe_path, output_path, changes):
-    """Create a modified lsd.jxe with changed EOL flags."""
-    flags, sc = read_flags(jxe_path)
+    """Create a modified lsd.jxe with changed base EOL flags."""
+    flags, sysconst_text = read_flags(jxe_path)
 
-    # Apply changes
-    modified_sc = sc
-    for name, new_val in changes.items():
-        # Use regex to replace the value
-        pattern = rf'^({re.escape(name)}\s*=\s*)\S+(.*)'
-        replacement = rf'\g<1>{new_val}\2'
-        modified_sc, count = re.subn(pattern, replacement, modified_sc, flags=re.MULTILINE)
+    modified_text = sysconst_text
+    for name, new_value in changes.items():
+        pattern = r'^({}\s*=\s*)\S+(.*)'.format(re.escape(name))
+        replacement = r'\g<1>{}\2'.format(new_value)
+        modified_text, count = re.subn(pattern, replacement, modified_text, flags=re.MULTILINE)
         if count == 0:
-            print(f"WARNING: {name} not found in sysconst.properties", file=sys.stderr)
+            print("WARNING: {} not found in sysconst.properties".format(name), file=sys.stderr)
         else:
-            old_val = flags.get(name, '?')
-            print(f"  {name}: {old_val} → {new_val}")
+            old_value = flags.get(name, '?')
+            print("  {}: {} -> {}".format(name, old_value, new_value))
 
-    # Create new JAR with modified sysconst.properties
-    # Copy all entries except the one we're modifying
     with zipfile.ZipFile(jxe_path, 'r') as zin:
         with zipfile.ZipFile(output_path, 'w', compression=zipfile.ZIP_STORED) as zout:
             for item in zin.infolist():
                 if item.filename == SYSCONST_PATH:
-                    # Write modified version
-                    zout.writestr(item, modified_sc.encode('utf-8'))
+                    zout.writestr(item, modified_text.encode('utf-8'))
                 else:
-                    # Copy original
-                    data = zin.read(item.filename)
-                    zout.writestr(item, data)
+                    zout.writestr(item, zin.read(item.filename))
 
-    print(f"\nWrote {output_path} ({os.path.getsize(output_path):,} bytes)")
+    print("\nWrote {} ({:,} bytes)".format(output_path, os.path.getsize(output_path)))
+
+
+def build_changes(args):
+    changes = OrderedDict()
+
+    for flag in args.enable:
+        normalized = normalize_flag_name(flag)
+        if normalized in HARDWARE_FEATURES:
+            print("WARNING: {} — {}".format(normalized, HARDWARE_FEATURES[normalized]))
+        changes[normalized] = '1'
+
+    for flag in args.disable:
+        changes[normalize_flag_name(flag)] = '0'
+
+    for flag, value in args.set:
+        changes[normalize_flag_name(flag)] = value
+
+    return changes
 
 
 def main():
-    p = argparse.ArgumentParser(description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument('jxe', help='Path to lsd.jxe')
-    p.add_argument('--output', '-o', help='Output path for modified lsd.jxe')
-    p.add_argument('--list', action='store_true', help='List all flags')
-    p.add_argument('--enable', action='append', default=[],
-                   metavar='FLAG', help='Enable a feature flag (set to 1)')
-    p.add_argument('--disable', action='append', default=[],
-                   metavar='FLAG', help='Disable a feature flag (set to 0)')
-    p.add_argument('--set', action='append', default=[], nargs=2,
-                   metavar=('FLAG', 'VALUE'),
-                   help='Set a flag to a specific value')
-    args = p.parse_args()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('jxe', help='Path to lsd.jxe')
+    parser.add_argument('--output', '-o', help='Output path for modified lsd.jxe')
+    parser.add_argument('--list', action='store_true', help='List base sysconst EOL flags')
+    parser.add_argument('--show-variant', action='store_true',
+                        help='Show raw variant selector properties and inferred active layers')
+    parser.add_argument('--list-variants', action='store_true',
+                        help='List available variant bundles with summary metadata')
+    parser.add_argument('--variant', action='append', default=[],
+                        metavar='NAME',
+                        help='Variant layer to inspect (can be specified multiple times)')
+    parser.add_argument('--diff-variants', nargs=2, metavar=('LEFT', 'RIGHT'),
+                        help='Show property differences between two variant bundles')
+    parser.add_argument('--show-range-locks', action='store_true',
+                        help='Show RANGE_ constraints for the resolved variant layers')
+    parser.add_argument('--show-effective', action='append', default=[],
+                        metavar='FLAG',
+                        help='Show effective value for an EOL flag after variant/range overlays')
+    parser.add_argument('--enable', action='append', default=[],
+                        metavar='FLAG', help='Enable a base sysconst feature flag (set to 1)')
+    parser.add_argument('--disable', action='append', default=[],
+                        metavar='FLAG', help='Disable a base sysconst feature flag (set to 0)')
+    parser.add_argument('--set', action='append', default=[], nargs=2,
+                        metavar=('FLAG', 'VALUE'),
+                        help='Set a base sysconst flag to a specific value')
+    args = parser.parse_args()
 
-    flags, _ = read_flags(args.jxe)
+    config = load_jxe_config(args.jxe)
+    flags = OrderedDict(
+        (name, value) for name, value in config['base_props'].items() if name.startswith('EOLFLAG_')
+    )
 
     if args.list:
-        disabled = {k: v for k, v in flags.items() if v == '0'}
-        enabled = {k: v for k, v in flags.items() if v != '0'}
+        summarize_flags(flags)
 
-        print(f"=== Enabled ({len(enabled)}) ===")
-        for k in sorted(enabled):
-            desc = SAFE_FEATURES.get(k, HARDWARE_FEATURES.get(k, ''))
-            suffix = f'  — {desc}' if desc else ''
-            print(f"  {k} = {enabled[k]}{suffix}")
+    if args.show_variant:
+        if args.list:
+            print()
+        print_variant_selector(config)
 
-        print(f"\n=== Disabled ({len(disabled)}) — can be enabled ===")
-        for k in sorted(disabled):
-            desc = SAFE_FEATURES.get(k, HARDWARE_FEATURES.get(k, ''))
-            safe = '✓' if k in SAFE_FEATURES else '⚠' if k in HARDWARE_FEATURES else ' '
-            suffix = f'  — {desc}' if desc else ''
-            print(f"  {safe} {k} = 0{suffix}")
+    if args.list_variants:
+        if args.list or args.show_variant:
+            print()
+        print_available_variants(config)
 
-        print(f"\n✓ = safe to enable  ⚠ = requires specific hardware")
-        return
+    if args.diff_variants:
+        left_name, right_name = args.diff_variants
+        if left_name not in config['variants'] or right_name not in config['variants']:
+            available = ', '.join(sorted(config['variants']))
+            parser.error(
+                "--diff-variants requires valid variant names. Available: {}".format(available)
+            )
+        if args.list or args.show_variant or args.list_variants:
+            print()
+        print_variant_diff(config, left_name, right_name)
 
-    # Build changes dict
-    changes = {}
-    for flag in args.enable:
-        if not flag.startswith('EOLFLAG_'):
-            flag = 'EOLFLAG_' + flag
-        if flag in HARDWARE_FEATURES:
-            print(f"WARNING: {flag} — {HARDWARE_FEATURES[flag]}")
-        changes[flag] = '1'
+    layers = []
+    if args.show_range_locks or args.show_effective:
+        try:
+            layers = get_variant_layers(config, args.variant)
+        except KeyError as exc:
+            parser.error(str(exc))
 
-    for flag in args.disable:
-        if not flag.startswith('EOLFLAG_'):
-            flag = 'EOLFLAG_' + flag
-        changes[flag] = '0'
+    if args.show_range_locks:
+        if args.list or args.show_variant or args.list_variants or args.diff_variants:
+            print()
+        print_range_locks(config, layers)
 
-    for flag, val in args.set:
-        if not flag.startswith('EOLFLAG_'):
-            flag = 'EOLFLAG_' + flag
-        changes[flag] = val
+    if args.show_effective:
+        if args.list or args.show_variant or args.list_variants or args.diff_variants or args.show_range_locks:
+            print()
+        print_effective_flags(config, layers, args.show_effective)
 
+    changes = build_changes(args)
     if not changes:
-        print("No changes specified. Use --enable, --disable, or --set.")
-        print("Use --list to see available flags.")
+        if any((
+            args.list,
+            args.show_variant,
+            args.list_variants,
+            args.diff_variants,
+            args.show_range_locks,
+            args.show_effective,
+        )):
+            return
+        print("No changes specified. Use --enable, --disable, --set, or one of the inspection flags.")
+        print("Use --list to see base EOL flags.")
         return
 
     if not args.output:
         print("ERROR: --output required for modifications.", file=sys.stderr)
         return
 
-    print(f"Modifying {len(changes)} EOL flag(s):")
+    print("Modifying {} base EOL flag(s):".format(len(changes)))
     modify_jxe(args.jxe, args.output, changes)
 
 

--- a/tools/inflate_ifs.py
+++ b/tools/inflate_ifs.py
@@ -193,7 +193,7 @@ def build_container_command(container_tool, image, ifs_path, output_path=None, e
     )
 
     command = [container_tool, 'run', '--rm', '-e', '{}=1'.format(CONTAINER_REEXEC_ENV), '-w', '/workspace']
-    if container_tool == 'podman':
+    if container_tool in ('podman', 'docker'):
         # Fedora/SELinux hosts commonly deny read access to arbitrary bind mounts unless
         # labels are adjusted. Disabling label confinement for this disposable container
         # avoids relabeling the repo or temp firmware directories on the host.

--- a/tools/inflate_ifs.py
+++ b/tools/inflate_ifs.py
@@ -193,6 +193,11 @@ def build_container_command(container_tool, image, ifs_path, output_path=None, e
     )
 
     command = [container_tool, 'run', '--rm', '-e', '{}=1'.format(CONTAINER_REEXEC_ENV), '-w', '/workspace']
+    if container_tool == 'podman':
+        # Fedora/SELinux hosts commonly deny read access to arbitrary bind mounts unless
+        # labels are adjusted. Disabling label confinement for this disposable container
+        # avoids relabeling the repo or temp firmware directories on the host.
+        command.extend(['--security-opt', 'label=disable'])
     for host_path, target_path in mounts:
         command.extend(['-v', '{}:{}'.format(host_path, target_path)])
     command.extend([image, 'sh', '-lc', inner_command])

--- a/tools/inflate_ifs.py
+++ b/tools/inflate_ifs.py
@@ -16,8 +16,12 @@ This tool:
   4. Optionally runs extract_qnx_ifs.py on the decompressed result
 
 The decompressor is a tiny C program (`qnx_ifs_decompress.c`, ~140 lines)
-built automatically on first run. Requires liblzo2-dev + libucl-dev +
-minilzo.c (auto-fetched from oberhumer.com).
+built automatically on first run. Requires gcc + libucl headers/libs.
+
+If those native dependencies are missing, the script can either be run
+explicitly in a disposable container with `--container`, or it will
+auto-fallback to podman/docker if available unless
+`--no-container-fallback` is set.
 
 Usage:
 
@@ -26,9 +30,13 @@ Usage:
 
     # decompress and extract to a directory
     python3 tools/inflate_ifs.py ifs-root.ifs --extract outdir/
+
+    # force a disposable container run
+    python3 tools/inflate_ifs.py ifs-root.ifs --extract outdir/ --container
 """
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -37,8 +45,11 @@ import urllib.request
 import tarfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
 DECOMPRESSOR_SRC = os.path.join(HERE, 'qnx_ifs_decompress.c')
 DECOMPRESSOR_BIN = os.path.join(HERE, 'qnx_ifs_decompress')
+CONTAINER_REEXEC_ENV = 'MMI3G_INFLATE_IFS_IN_CONTAINER'
+DEFAULT_CONTAINER_IMAGE = 'debian:bookworm-slim'
 
 
 def ensure_minilzo():
@@ -51,12 +62,16 @@ def ensure_minilzo():
     url = 'https://www.oberhumer.com/opensource/lzo/download/minilzo-2.10.tar.gz'
     tgz = os.path.join(HERE, 'minilzo-2.10.tar.gz')
     urllib.request.urlretrieve(url, tgz)
-    with tarfile.open(tgz) as t:
-        for n in ('minilzo-2.10/minilzo.c', 'minilzo-2.10/minilzo.h',
-                  'minilzo-2.10/lzoconf.h', 'minilzo-2.10/lzodefs.h'):
-            m = t.getmember(n)
-            m.name = os.path.basename(n)
-            t.extract(m, HERE)
+    with tarfile.open(tgz) as archive:
+        for name in (
+            'minilzo-2.10/minilzo.c',
+            'minilzo-2.10/minilzo.h',
+            'minilzo-2.10/lzoconf.h',
+            'minilzo-2.10/lzodefs.h',
+        ):
+            member = archive.getmember(name)
+            member.name = os.path.basename(name)
+            archive.extract(member, HERE)
     os.remove(tgz)
 
 
@@ -68,7 +83,6 @@ def ensure_built():
 
     ensure_minilzo()
 
-    # minilzo.c expects #include <lzo/minilzo.h>; provide that path
     lzo_dir = os.path.join(HERE, 'lzo')
     os.makedirs(lzo_dir, exist_ok=True)
     src = os.path.join(HERE, 'minilzo.h')
@@ -76,7 +90,7 @@ def ensure_built():
     if not os.path.exists(dst):
         shutil.copy(src, dst)
 
-    print(f'[inflate_ifs] compiling {DECOMPRESSOR_SRC} -> {DECOMPRESSOR_BIN}',
+    print('[inflate_ifs] compiling {} -> {}'.format(DECOMPRESSOR_SRC, DECOMPRESSOR_BIN),
           file=sys.stderr)
     subprocess.check_call([
         'gcc', '-Wall', '-O2',
@@ -89,41 +103,184 @@ def ensure_built():
     return DECOMPRESSOR_BIN
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument('ifs', help='Input compressed .ifs image')
-    ap.add_argument('-o', '--output',
-                    help='Output decompressed IFS path (default: <input>.decomp)')
-    ap.add_argument('--extract', metavar='DIR',
-                    help='After decompressing, extract files to DIR using extract_qnx_ifs.py')
-    ap.add_argument('--keep-decomp', action='store_true',
-                    help='Keep the decompressed intermediate file even when using --extract')
-    args = ap.parse_args()
+def resolve_container_tool(preferred=None):
+    if preferred:
+        return preferred if shutil.which(preferred) else None
+    for candidate in ('podman', 'docker'):
+        if shutil.which(candidate):
+            return candidate
+    return None
 
-    binary = ensure_built()
 
+def existing_mount_root(path):
+    candidate = os.path.abspath(path)
+    if not os.path.isdir(candidate):
+        candidate = os.path.dirname(candidate)
+    while not os.path.exists(candidate):
+        parent = os.path.dirname(candidate)
+        if parent == candidate:
+            break
+        candidate = parent
+    return candidate
+
+
+def translate_host_path(host_path, repo_root, extra_roots):
+    repo_root = os.path.abspath(repo_root)
+    host_path = os.path.abspath(host_path)
+
+    if host_path == repo_root:
+        return '/workspace'
+    if host_path.startswith(repo_root + os.sep):
+        return '/workspace' + host_path[len(repo_root):]
+
+    for root, target in extra_roots:
+        if host_path == root:
+            return target
+        if root == '/':
+            return target + host_path
+        if host_path.startswith(root + os.sep):
+            return target + host_path[len(root):]
+
+    raise ValueError('path {} was not covered by container mounts'.format(host_path))
+
+
+def build_container_command(container_tool, image, ifs_path, output_path=None, extract_path=None,
+                            keep_decomp=False, repo_root=None):
+    repo_root = os.path.abspath(repo_root or REPO_ROOT)
+
+    mounts = [(repo_root, '/workspace')]
+    extra_roots = []
+    seen_roots = {repo_root}
+
+    relevant_paths = [os.path.abspath(ifs_path)]
+    if output_path:
+        relevant_paths.append(os.path.abspath(output_path))
+    if extract_path:
+        relevant_paths.append(os.path.abspath(extract_path))
+
+    for path in relevant_paths:
+        if path == repo_root or path.startswith(repo_root + os.sep):
+            continue
+        root = existing_mount_root(path)
+        if root in seen_roots:
+            continue
+        target = '/mnt/host{}'.format(len(extra_roots))
+        extra_roots.append((root, target))
+        mounts.append((root, target))
+        seen_roots.add(root)
+
+    translated_ifs = translate_host_path(ifs_path, repo_root, extra_roots)
+    translated_output = translate_host_path(output_path, repo_root, extra_roots) if output_path else None
+    translated_extract = translate_host_path(extract_path, repo_root, extra_roots) if extract_path else None
+
+    inner_args = [
+        'python3',
+        '/workspace/tools/inflate_ifs.py',
+        translated_ifs,
+        '--no-container-fallback',
+    ]
+    if translated_output:
+        inner_args.extend(['-o', translated_output])
+    if translated_extract:
+        inner_args.extend(['--extract', translated_extract])
+    if keep_decomp:
+        inner_args.append('--keep-decomp')
+
+    inner_command = (
+        'apt-get update && '
+        'apt-get install -y --no-install-recommends gcc libucl-dev python3 ca-certificates && '
+        '{}'.format(' '.join(shlex.quote(arg) for arg in inner_args))
+    )
+
+    command = [container_tool, 'run', '--rm', '-e', '{}=1'.format(CONTAINER_REEXEC_ENV), '-w', '/workspace']
+    for host_path, target_path in mounts:
+        command.extend(['-v', '{}:{}'.format(host_path, target_path)])
+    command.extend([image, 'sh', '-lc', inner_command])
+    return command
+
+
+def run_in_container(args, decomp_path):
+    tool = resolve_container_tool(args.container_tool)
+    if not tool:
+        requested = args.container_tool or 'podman/docker'
+        print('[inflate_ifs] no usable container runtime found ({})'.format(requested), file=sys.stderr)
+        return 1
+
+    command = build_container_command(
+        container_tool=tool,
+        image=args.container_image,
+        ifs_path=os.path.abspath(args.ifs),
+        output_path=os.path.abspath(decomp_path),
+        extract_path=os.path.abspath(args.extract) if args.extract else None,
+        keep_decomp=args.keep_decomp,
+        repo_root=REPO_ROOT,
+    )
+    print('[inflate_ifs] running in {} using {}'.format(tool, args.container_image), file=sys.stderr)
+    return subprocess.call(command)
+
+
+def should_try_container(args):
+    if os.environ.get(CONTAINER_REEXEC_ENV):
+        return False
+    if args.no_container_fallback:
+        return False
+    return resolve_container_tool(args.container_tool) is not None
+
+
+def compute_decomp_path(args):
     if args.output:
-        decomp_path = args.output
-        owns_decomp = False
-    elif args.extract and not args.keep_decomp:
-        decomp_path = tempfile.mktemp(suffix='.ifs.decomp')
-        owns_decomp = True
-    else:
-        decomp_path = args.ifs + '.decomp'
-        owns_decomp = False
+        return args.output, False
+    if args.extract and not args.keep_decomp:
+        return tempfile.mktemp(suffix='.ifs.decomp'), True
+    return args.ifs + '.decomp', False
 
-    print(f'[inflate_ifs] decompressing {args.ifs}', file=sys.stderr)
-    r = subprocess.run([binary, args.ifs, decomp_path])
-    if r.returncode != 0:
-        sys.exit(f'[inflate_ifs] decompressor failed')
 
-    print(f'[inflate_ifs] wrote {decomp_path} ({os.path.getsize(decomp_path):,} bytes)',
-          file=sys.stderr)
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('ifs', help='Input compressed .ifs image')
+    parser.add_argument('-o', '--output',
+                        help='Output decompressed IFS path (default: <input>.decomp)')
+    parser.add_argument('--extract', metavar='DIR',
+                        help='After decompressing, extract files to DIR using extract_qnx_ifs.py')
+    parser.add_argument('--keep-decomp', action='store_true',
+                        help='Keep the decompressed intermediate file even when using --extract')
+    parser.add_argument('--container', action='store_true',
+                        help='Run inside a disposable podman/docker container')
+    parser.add_argument('--container-tool', choices=['podman', 'docker'],
+                        help='Container runtime to use for --container or auto-fallback')
+    parser.add_argument('--container-image', default=DEFAULT_CONTAINER_IMAGE,
+                        help='Container image for --container / auto-fallback '
+                             '(default: {})'.format(DEFAULT_CONTAINER_IMAGE))
+    parser.add_argument('--no-container-fallback', action='store_true',
+                        help='Disable automatic podman/docker fallback when local deps are missing')
+    args = parser.parse_args()
+
+    decomp_path, owns_decomp = compute_decomp_path(args)
+
+    if args.container and not os.environ.get(CONTAINER_REEXEC_ENV):
+        sys.exit(run_in_container(args, decomp_path))
+
+    try:
+        binary = ensure_built()
+    except (FileNotFoundError, OSError, subprocess.CalledProcessError) as exc:
+        if should_try_container(args):
+            print('[inflate_ifs] local build failed ({}); retrying in container'.format(exc),
+                  file=sys.stderr)
+            sys.exit(run_in_container(args, decomp_path))
+        raise
+
+    print('[inflate_ifs] decompressing {}'.format(args.ifs), file=sys.stderr)
+    result = subprocess.run([binary, args.ifs, decomp_path])
+    if result.returncode != 0:
+        sys.exit('[inflate_ifs] decompressor failed')
+
+    print('[inflate_ifs] wrote {} ({:,} bytes)'.format(
+        decomp_path, os.path.getsize(decomp_path)), file=sys.stderr)
 
     if args.extract:
         extractor = os.path.join(HERE, 'extract_qnx_ifs.py')
-        r = subprocess.run(['python3', extractor, decomp_path, args.extract])
-        if r.returncode != 0:
+        result = subprocess.run(['python3', extractor, decomp_path, args.extract])
+        if result.returncode != 0:
             sys.exit('[inflate_ifs] extractor failed')
         if owns_decomp:
             os.unlink(decomp_path)


### PR DESCRIPTION
## What changed

- expands `tools/eol_modifier.py` from a base-flag patcher into an inspection-first tool for `lsd.jxe`
- adds support for showing `variant.properties`, listing variant bundles, diffing variants, surfacing `RANGE_` locks, and showing effective EOL values after overlaying variant layers
- adds a portable execution path to `tools/inflate_ifs.py` with explicit `--container` support and automatic podman/docker fallback when local native deps are missing
- updates `tools/README.md` to document the new `eol_modifier.py` inspection workflow and the containerized IFS extraction path
- adds unit coverage in `tests/test_firmware_tools.py` for both the new `lsd.jxe` inspection logic and the container command/mount builder

## Why

The repo already had the raw ingredients for two common firmware-research pain points:

1. understanding why a feature is blocked inside `lsd.jxe` without blindly patching flags
2. getting `inflate_ifs.py` running on hosts that do not already have the native build deps installed

This change makes both workflows less brittle. `eol_modifier.py` can now be used as a read-only research tool for market/variant/range analysis, and `inflate_ifs.py` can run on clean hosts through a disposable container instead of failing immediately on missing `gcc` / `libucl`.

## User impact

- firmware researchers can inspect effective `lsd.jxe` behavior before patching
- contributors on fresh Linux/macOS/Fedora hosts can still use `inflate_ifs.py` without hand-installing native dependencies first
- existing local-native `inflate_ifs.py` behavior is preserved when the host build works

## Validation

- `python3 -m unittest tests.test_firmware_tools -v`
- `python3 -m unittest discover -s tests -v`
- `python3 tools/eol_modifier.py --help`
- `python3 tools/inflate_ifs.py --help`

## Notes

- the `inflate_ifs.py` container path is additive: it only runs automatically when the local native build fails and podman/docker is available, unless `--no-container-fallback` is set
- no module payloads or firmware patching behavior were removed
