### PR TITLE
Fix Pages artifact deployment source

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure Pages uses workflow deployments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PUT \
+            "repos/${GITHUB_REPOSITORY}/pages" \
+            -f build_type=workflow \
+            --silent
+
       - uses: actions/configure-pages@v5
 
       - name: Stage site

--- a/tests/test_pages_workflow.py
+++ b/tests/test_pages_workflow.py
@@ -12,6 +12,7 @@ class PagesWorkflowTests(unittest.TestCase):
         cls.source = PAGES_WORKFLOW.read_text(encoding='utf-8')
 
     def test_pages_workflow_mirrors_p0824_payload_without_committing_zip(self):
+        self.assertIn('build_type=workflow', self.source)
         self.assertIn('actions/deploy-pages@v4', self.source)
         self.assertIn('actions/upload-pages-artifact@v3', self.source)
         self.assertIn('gh release download v1.0-gemmi-p0824', self.source)


### PR DESCRIPTION
## Summary
- configure GitHub Pages to use workflow-backed deployments before uploading the Pages artifact
- keep the P0824 GEMMI ZIP out of the repository while making `/payloads/gemmi_p0824_eu_vw.zip` serve from Pages
- add a regression assertion so the workflow keeps the required `build_type=workflow` setting

## Why
PR #7 merged successfully and the Pages workflow uploaded an artifact containing `payloads/gemmi_p0824_eu_vw.zip`, but the live site still returned 404 because the repository Pages settings remained on legacy `main:/docs` publishing. In that mode GitHub serves only committed files from `docs/`, not files staged into the Actions Pages artifact.

The new workflow step calls the GitHub Pages API with `build_type=workflow` so `actions/deploy-pages` becomes the active publishing source.

## Testing
- `python -m pytest tests/test_pages_workflow.py tests/test_web_builder_parity.py tests/test_generate_manifest.py tests/test_module_contracts.py`
- `python -m pytest`

## Maintainer note
If the workflow token cannot change Pages settings in this repository, manually set **Settings -> Pages -> Build and deployment -> Source** to **GitHub Actions**, then rerun the `Deploy GitHub Pages` workflow. After that, `https://dspl1236.github.io/MMI3G-Toolkit/payloads/gemmi_p0824_eu_vw.zip` should resolve without committing the ZIP to `docs/`.
