### PR TITLE
Make the Pages site work at its root and self-hostable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Stage site
         run: |
-          mkdir -p _site/payloads
+          mkdir -p _site/app/payloads
           cp -R docs/. _site/
 
       - name: Download GEMMI P0824 payload
@@ -50,8 +50,8 @@ jobs:
           gh release download v1.0-gemmi-p0824 \
             --repo "$GITHUB_REPOSITORY" \
             --pattern gemmi_p0824_eu_vw.zip \
-            --dir _site/payloads
-          test "$(wc -c < _site/payloads/gemmi_p0824_eu_vw.zip)" -eq 9823685
+            --dir _site/app/payloads
+          test "$(wc -c < _site/app/payloads/gemmi_p0824_eu_vw.zip)" -eq 9823685
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -127,7 +127,7 @@ const MODULES_DISPLAY = [
   { id: "google-earth-p0824-deploy", name: "P0824 GEMMI Deploy", status: "alpha",
     desc: "Deploy bundled EU VW P0824 GEMMI donor payload to /mnt/nav/gemmi",
     compat: ["RNS-850"], category: "system",
-    prereq: null, payloadUrl: "https://dspl1236.github.io/MMI3G-Toolkit/payloads/gemmi_p0824_eu_vw.zip", detail: "Backs up the existing /mnt/nav/gemmi tree, copies the bundled EU VW P0824 GEMMI payload from SD card root /gemmi, and adds minimal drivers.ini auth-bypass settings. Does not patch lsd.jxe or firmware. The web app fetches the payload from the same GitHub Pages origin to avoid browser CORS limits." },
+    prereq: null, payloadUrl: "payloads/gemmi_p0824_eu_vw.zip", detail: "Backs up the existing /mnt/nav/gemmi tree, copies the bundled EU VW P0824 GEMMI payload from SD card root /gemmi, and adds minimal drivers.ini auth-bypass settings. Does not patch lsd.jxe or firmware. The web app fetches the payload from the same GitHub Pages origin to avoid browser CORS limits." },
   { id: "google-earth-p0824-restore", name: "P0824 GEMMI Restore", status: "alpha",
     desc: "Restore /mnt/nav/gemmi from the backup made by P0824 GEMMI Deploy",
     compat: ["RNS-850"], category: "system",

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -127,7 +127,7 @@ const MODULES_DISPLAY = [
   { id: "google-earth-p0824-deploy", name: "P0824 GEMMI Deploy", status: "alpha",
     desc: "Deploy bundled EU VW P0824 GEMMI donor payload to /mnt/nav/gemmi",
     compat: ["RNS-850"], category: "system",
-    prereq: null, payloadUrl: "payloads/gemmi_p0824_eu_vw.zip", detail: "Backs up the existing /mnt/nav/gemmi tree, copies the bundled EU VW P0824 GEMMI payload from SD card root /gemmi, and adds minimal drivers.ini auth-bypass settings. Does not patch lsd.jxe or firmware. The web app fetches the payload from the same GitHub Pages origin to avoid browser CORS limits." },
+    prereq: null, payloadUrl: "payloads/gemmi_p0824_eu_vw.zip", detail: "Backs up the existing /mnt/nav/gemmi tree, copies the bundled EU VW P0824 GEMMI payload from SD card root /gemmi, and adds minimal drivers.ini auth-bypass settings. Does not patch lsd.jxe or firmware. The web app fetches the payload relative to its own origin, so the request is same-origin wherever the site is hosted and never hits browser CORS limits." },
   { id: "google-earth-p0824-restore", name: "P0824 GEMMI Restore", status: "alpha",
     desc: "Restore /mnt/nav/gemmi from the backup made by P0824 GEMMI Deploy",
     compat: ["RNS-850"], category: "system",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>MMI3G-Toolkit</title>
+<meta http-equiv="refresh" content="0; url=app/">
+<link rel="canonical" href="app/">
+<p>Redirecting to the <a href="app/">MMI-Toolkit SD Card Builder</a>.</p>

--- a/tests/test_web_builder_parity.py
+++ b/tests/test_web_builder_parity.py
@@ -56,10 +56,14 @@ class WebBuilderParityTests(unittest.TestCase):
         p0824_card = self.source[p0824_start:p0824_end]
 
         self.assertNotIn('cliOnly: true', p0824_card)
+        # Relative, so the fetch is same-origin wherever the site is served
+        # from - GitHub Pages here, a self-hosted mirror elsewhere. Asserting a
+        # hardcoded host would pin the app to one deployment.
         self.assertIn(
-            'payloadUrl: "https://dspl1236.github.io/MMI3G-Toolkit/payloads/gemmi_p0824_eu_vw.zip"',
+            'payloadUrl: "payloads/gemmi_p0824_eu_vw.zip"',
             p0824_card,
         )
+        self.assertNotIn('dspl1236.github.io', p0824_card)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three small changes so the published site works at its root and can be served from somewhere other than `dspl1236.github.io`.

### 1. `/` no longer 404s

`pages.yml` copies `docs/.` into the site root, and `docs/` has no `index.html` — so https://dspl1236.github.io/MMI3G-Toolkit/ returns **404** today while the app itself is fine at `/app/`. Adds `docs/index.html` redirecting to `app/`.

### 2. The payload is resolved relative to the app

`payloadUrl` was hardcoded to `https://dspl1236.github.io/MMI3G-Toolkit/payloads/...`, so any other copy of the site still pulls a 9.8 MB file from GitHub Pages. It is now `payloads/gemmi_p0824_eu_vw.zip`, resolved against the app's own directory.

### 3. The workflow stages the payload beside the app

To match, `gh release download` now targets `_site/app/payloads` instead of `_site/payloads`. The existing size assertion moves with it, so a truncated download still fails the build.

Net effect: the same relative path is correct whether the app is served at `/app/` (here) or at the site root (a mirror), with no further edits.

---

Context: these repos are now mirrored to a self-hosted Forgejo instance with GitHub Pages-style hosting. Forgejo disables the releases unit on mirrored repos, so the payload cannot come from the mirror and is fetched from this public release instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)